### PR TITLE
refactor: 兼容低版本 PHP-Parser

### DIFF
--- a/src/Processor/Method/FieldMetadataBuilder.php
+++ b/src/Processor/Method/FieldMetadataBuilder.php
@@ -60,7 +60,7 @@ class FieldMetadataBuilder
         }
 
         if ($propertyType instanceof Name) {
-            $this->fieldMetadata->addFieldType('\\' . implode('\\', $propertyType->getParts()));
+            $this->fieldMetadata->addFieldType('\\' . $propertyType->toString());
 
             return;
         }

--- a/tests/Mock/GetterMethodComment.php
+++ b/tests/Mock/GetterMethodComment.php
@@ -43,4 +43,6 @@ class GetterMethodComment
      * @var string
      */
     private $foo;
+
+    private FooSub $fooSub;
 }


### PR DESCRIPTION
PHP-Parser 的 `Name::getParts()` 方法是在 [4.16.0](https://github.com/nikic/PHP-Parser/releases/tag/v4.16) 版本新增的，4.16.0 以下版本使用时会抛出异常提示 `getParts` 方法不存在。

```
Error : Call to undefined method PhpParser\Node\Name\FullyQualified::getParts()
/code/php-accessor/src/Processor/Method/FieldMetadataBuilder.php:63
/code/php-accessor/src/Processor/Method/FieldMetadataBuilder.php:38
/code/php-accessor/src/Processor/MethodFactory.php:72
/code/php-accessor/src/Processor/ClassProcessor.php:175
/code/php-accessor/src/Processor/ClassProcessor.php:158
/code/php-accessor/src/Processor/ClassProcessor.php:69
```


